### PR TITLE
Fix lifetime elision warning since rustc 1.89

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -124,7 +124,7 @@ impl Theme {
         }
     }
 
-    pub fn sprite(&self, key: &SpriteKey) -> ArrayView2<u8> {
+    pub fn sprite(&self, key: &SpriteKey) -> ArrayView2<'_, u8> {
         let y = key.y();
         let x = key.x();
         self.sprite.slice(s!(
@@ -152,7 +152,7 @@ impl Themes {
         }
     }
 
-    pub fn font(&self) -> &Font {
+    pub fn font(&self) -> &Font<'_> {
         &self.font
     }
 


### PR DESCRIPTION
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/theme.rs:127:19
    |
127 |     pub fn sprite(&self, key: &SpriteKey) -> ArrayView2<u8> {
    |                   ^^^^^                      -------------- the same lifetime is hidden here
    |                   |
    |                   the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
127 |     pub fn sprite(&self, key: &SpriteKey) -> ArrayView2<'_, u8> {
    |                                                         +++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/theme.rs:155:17
    |
155 |     pub fn font(&self) -> &Font {
    |                 ^^^^^     -----
    |                 |         ||
    |                 |         |the same lifetime is hidden here
    |                 |         the same lifetime is elided here
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
155 |     pub fn font(&self) -> &Font<'_> {
    |                                ++++

warning: `lila-gif` (bin "lila-gif") generated 2 warnings
```